### PR TITLE
implementations/js: response type binary fixed in browser

### DIFF
--- a/implementations/js/src/util.ts
+++ b/implementations/js/src/util.ts
@@ -34,11 +34,13 @@ export function fromAxiosResponse(
 
   // encode bytes as base64 string if response is array buffer
   if (axiosResponse.config.responseType == "arraybuffer") {
-    if (!Buffer.isBuffer(axiosResponse.data)) {
-      throw Error(
-        "HttpPlugin: Axios response data malformed, must be a buffer. Type: " +
+    if (!(axiosResponse.data instanceof ArrayBuffer)) {
+      if (!Buffer.isBuffer(axiosResponse.data)) {
+        throw Error(
+          "HttpPlugin: Axios response data malformed, must be a buffer. Type: " +
           typeof axiosResponse.data
-      );
+        );
+      }
     }
 
     return {


### PR DESCRIPTION
after trying to fetch a wrapper using the HTTP uri resolver from the browser, I noticed it was not working as expected. 

The reason was that we're doing `Buffer.isBuffer` to check if the response if a buffer, but from the browser it doesn't work, so we need to add a verification to check if the response data is an instance of `ArrayBuffer`. This fixed the problem

It's worth mentioning that I think we should improve ASAP how we handle errors in the URI resolvers, but that's another topic :P