### PR TITLE
request and response body type from String -> JSON

### DIFF
--- a/interface/polywrap.graphql
+++ b/interface/polywrap.graphql
@@ -2,7 +2,7 @@ type Response {
   status: Int!
   statusText: String!
   headers: Map @annotate(type: "Map<String!, String!>")
-  body: String
+  body: JSON
 }
 
 type Request {
@@ -10,7 +10,7 @@ type Request {
   urlParams: Map @annotate(type: "Map<String!, String!>")
   responseType: ResponseType!
   """The body of the request. If present, the `formData` property will be ignored."""
-  body: String
+  body: JSON
   """
   An alternative to the standard request body, 'formData' is expected to be in the 'multipart/form-data' format.
   If present, the `body` property is not null, `formData` will be ignored.

--- a/interface/polywrap.graphql
+++ b/interface/polywrap.graphql
@@ -2,7 +2,7 @@ type Response {
   status: Int!
   statusText: String!
   headers: Map @annotate(type: "Map<String!, String!>")
-  body: JSON
+  body: String
 }
 
 type Request {


### PR DESCRIPTION
An HTTP request or response body must be a valid JSON string, but this is not reflected in our HTTP interface.

If a request body is not a valid JSON string, the user will encounter an exception.

I tried to do this in a test and thought it was a bug in the Rust HTTP plugin: https://github.com/polywrap/rust-client/issues/196